### PR TITLE
BITMAKER-786: Configure entrypoint to be installed via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ The package implements a wrapper layer to extract job data from environment, pre
 
 ## Installation
 ```
-python setup.py install
+python setup.py install 
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='scraping-product-entrypoint',
+    name='bitmaker-entrypoint',
     version='0.1',
     description='Scrapy entrypoint for Bitmaker job runner',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     packages=find_packages(),
     install_requires=[
         'Scrapy>=1.0',
@@ -14,4 +16,12 @@ setup(
             'bm-describe-project = bm_scrapy.__main__:describe_project',
         ],
     },
+    classifiers=[
+        'Framework :: Scrapy',
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Topic :: Utilities',
+    ],
 )


### PR DESCRIPTION
#### Ticket URL:

- http://tasks.bitmaker.la/issues/786

#### Description

- The entrypoint must be installed via `pip`
- Configure the `setup.py` file

#### Checklist

- [x] Check that only one commit is added in the PR with the correct format
- [x] Rebase my branch