### PR TITLE
BITMAKER-993: Add support for multibroker kafka cluster

### DIFF
--- a/bm_scrapy/producer.py
+++ b/bm_scrapy/producer.py
@@ -8,17 +8,18 @@ from kafka import KafkaProducer
 
 def connect_kafka_producer():
     _producer = None
-    bootstrap_server = [
-        "{}:{}".format(
-            os.getenv("KAFKA_ADVERTISED_HOST_NAME", "localhost"),
-            os.getenv("KAFKA_ADVERTISED_PORT", "9092"),
-        )
+    kafka_advertised_port = os.getenv("KAFKA_ADVERTISED_PORT", "9092")
+    kafka_advertised_listeners = os.getenv("KAFKA_ADVERTISED_LISTENERS").split(",")
+    bootstrap_servers = [
+        "{}:{}".format(kafka_advertised_listener, kafka_advertised_port)
+        for kafka_advertised_listener in kafka_advertised_listeners
     ]
     try:
         _producer = KafkaProducer(
-            bootstrap_servers=bootstrap_server,
-            api_version=(0, 10),
+            bootstrap_servers=bootstrap_servers,
             value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+            acks=1,
+            retries=1,
         )
     except Exception as ex:
         logger("Exception while connecting Kafka")


### PR DESCRIPTION
#### Ticket url(s):
- https://tasks.bitmaker.dev/issues/993

#### Description:
- Read multiple advertised hosts from env.
- Set the retries to 1 when a message is not sent.

#### Checklist:
- [X] Check that only one commit is added in the PR with the correct format
- [X] Rebase my branch
- [X] Run `black .`