### PR TITLE
BITMAKER-1295: Show Dumping Scrapy Stats

### DIFF
--- a/bm_scrapy/extensions.py
+++ b/bm_scrapy/extensions.py
@@ -51,10 +51,12 @@ class ItemStorageExtension:
         self.producer.send("job_items", value=data).add_errback(on_kafka_send_error)
 
     def spider_closed(self, spider, reason):
+        print("---BITMAKER---")
         data = {
-            "jid": self.job_jid,
+            "jid": os.getenv("BM_SPIDER_JOB"),
             "payload": {
                 "finish_reason": str(reason),
+                "stats": str(self.stats.get_stats())
             },
         }
         self.update_job_status(

--- a/bm_scrapy/extensions.py
+++ b/bm_scrapy/extensions.py
@@ -12,7 +12,8 @@ FINISHED_REASON = "finished"
 
 
 class ItemStorageExtension:
-    def __init__(self):
+    def __init__(self,stats):
+        self.stats = stats
         self.producer = connect_kafka_producer()
         exporter_kwargs = {"binary": False}
         self.exporter = PythonItemExporter(**exporter_kwargs)
@@ -36,7 +37,7 @@ class ItemStorageExtension:
 
     @classmethod
     def from_crawler(cls, crawler):
-        ext = cls()
+        ext = cls(crawler.stats)
         crawler.signals.connect(ext.item_scraped, signals.item_scraped)
         crawler.signals.connect(ext.spider_opened, signals.spider_opened)
         crawler.signals.connect(ext.spider_closed, signals.spider_closed)
@@ -51,13 +52,9 @@ class ItemStorageExtension:
         self.producer.send("job_items", value=data).add_errback(on_kafka_send_error)
 
     def spider_closed(self, spider, reason):
-        print("---BITMAKER---")
         data = {
             "jid": os.getenv("BM_SPIDER_JOB"),
-            "payload": {
-                "finish_reason": str(reason),
-                "stats": str(self.stats.get_stats())
-            },
+            "payload": self.stats.get_stats(),
         }
         self.update_job_status(
             COMPLETED_STATUS if reason == FINISHED_REASON else INCOMPLETE_STATUS

--- a/bm_scrapy/extensions.py
+++ b/bm_scrapy/extensions.py
@@ -14,7 +14,7 @@ FINISHED_REASON = "finished"
 
 
 class ItemStorageExtension:
-    def __init__(self,stats):
+    def __init__(self, stats):
         self.stats = stats
         self.producer = connect_kafka_producer()
         exporter_kwargs = {"binary": False}
@@ -54,7 +54,7 @@ class ItemStorageExtension:
         self.producer.send("job_items", value=data).add_errback(on_kafka_send_error)
 
     def spider_closed(self, spider, reason):
-        parser_stats = json.dumps(self.stats.get_stats(),default=datetime_to_json)
+        parser_stats = json.dumps(self.stats.get_stats(), default=datetime_to_json)
         data = {
             "jid": os.getenv("BM_SPIDER_JOB"),
             "payload": json.loads(parser_stats),

--- a/bm_scrapy/extensions.py
+++ b/bm_scrapy/extensions.py
@@ -1,5 +1,6 @@
 import os
 import requests
+import json
 
 from bm_scrapy.utils import datetime_to_json
 from scrapy import signals

--- a/bm_scrapy/extensions.py
+++ b/bm_scrapy/extensions.py
@@ -54,9 +54,10 @@ class ItemStorageExtension:
         self.producer.send("job_items", value=data).add_errback(on_kafka_send_error)
 
     def spider_closed(self, spider, reason):
+        parser_stats = json.dumps(self.stats.get_stats(),default=datetime_to_json)
         data = {
             "jid": os.getenv("BM_SPIDER_JOB"),
-            "payload": json.dumps(self.stats.get_stats(),default=datetime_to_json),
+            "payload": json.loads(parser_stats),
         }
         self.update_job_status(
             COMPLETED_STATUS if reason == FINISHED_REASON else INCOMPLETE_STATUS

--- a/bm_scrapy/extensions.py
+++ b/bm_scrapy/extensions.py
@@ -1,6 +1,7 @@
 import os
 import requests
 
+from bm_scrapy.utils import datetime_to_json
 from scrapy import signals
 from scrapy.exporters import PythonItemExporter
 from bm_scrapy.producer import connect_kafka_producer, on_kafka_send_error
@@ -54,7 +55,7 @@ class ItemStorageExtension:
     def spider_closed(self, spider, reason):
         data = {
             "jid": os.getenv("BM_SPIDER_JOB"),
-            "payload": self.stats.get_stats(),
+            "payload": json.dumps(self.stats.get_stats(),default=datetime_to_json),
         }
         self.update_job_status(
             COMPLETED_STATUS if reason == FINISHED_REASON else INCOMPLETE_STATUS

--- a/bm_scrapy/utils.py
+++ b/bm_scrapy/utils.py
@@ -7,6 +7,7 @@ def parse_time(date=None):
     parsed_time = date.strftime("%d/%m/%Y %H:%M:%S.%f")[:-3]
     return parsed_time
 
+
 def datetime_to_json(o):
     if isinstance(o, datetime):
         return o.__str__()

--- a/bm_scrapy/utils.py
+++ b/bm_scrapy/utils.py
@@ -6,3 +6,7 @@ def parse_time(date=None):
         date = datetime.now()
     parsed_time = date.strftime("%d/%m/%Y %H:%M:%S.%f")[:-3]
     return parsed_time
+
+def datetime_to_json(o):
+    if isinstance(o, datetime.datetime):
+        return o.__str__()

--- a/bm_scrapy/utils.py
+++ b/bm_scrapy/utils.py
@@ -8,5 +8,5 @@ def parse_time(date=None):
     return parsed_time
 
 def datetime_to_json(o):
-    if isinstance(o, datetime.datetime):
+    if isinstance(o, datetime):
         return o.__str__()

--- a/bm_scrapy/utils.py
+++ b/bm_scrapy/utils.py
@@ -11,3 +11,4 @@ def parse_time(date=None):
 def datetime_to_json(o):
     if isinstance(o, datetime):
         return o.__str__()
+    raise TypeError("Type %s not serializable" % type(obj))

--- a/bm_scrapy/utils.py
+++ b/bm_scrapy/utils.py
@@ -11,4 +11,4 @@ def parse_time(date=None):
 def datetime_to_json(o):
     if isinstance(o, datetime):
         return o.__str__()
-    raise TypeError("Type %s not serializable" % type(obj))
+    raise TypeError("Type %s not serializable" % type(o))


### PR DESCRIPTION
#### Ticket url(s):
- https://tasks.bitmaker.dev/issues/1295

#### Description:
- Enable recolection of scrapy stats when spider finish. The stats are send to kafka topic: job_logs

#### Checklist:
- [X] Check that only one commit is added in the PR with the correct format
- [X] Rebase my branch
- [X] Run `black .`