### PR TITLE
BITMAKER-1864: Change job_logs topic to job_stats topic

### DIFF
--- a/estela_scrapy/extensions.py
+++ b/estela_scrapy/extensions.py
@@ -84,5 +84,5 @@ class ItemStorageExtension:
             "jid": os.getenv("ESTELA_SPIDER_JOB"),
             "payload": json.loads(parser_stats),
         }
-        self.producer.send("job_logs", value=data).add_errback(on_kafka_send_error)
+        self.producer.send("job_stats", value=data).add_errback(on_kafka_send_error)
         self.producer.flush()

--- a/estela_scrapy/settings.py
+++ b/estela_scrapy/settings.py
@@ -38,6 +38,7 @@ def load_default_settings(settings):
     # memory_limit [!] missing
     # set other default settings with max priority
     settings.setdict({"LOG_LEVEL": "INFO"}, priority="cmdline")
+    settings.setdict({"LOG_ENABLED": False}, priority="cmdline")
 
 
 def populate_settings():


### PR DESCRIPTION
## Ticket
- https://tasks.bitmaker.dev/issues/1864
## Description
- Change topic which scrapy stats will send, from job_logs to job_stats.