### PR TITLE
BITMAKER-1997: Add send logs to kafka from entrypoint

### DIFF
--- a/estela_scrapy/__main__.py
+++ b/estela_scrapy/__main__.py
@@ -37,7 +37,7 @@ def describe_project():
 
     setup_scrapy_conf()
 
-    run_code(["scrapy", "describe_project"] + sys.argv[1:], "estela_scrapy.commands")
+    run_code(["scrapy", "describe_project"] + sys.argv[1:], commands_module="estela_scrapy.commands")
 
 
 def setup_and_launch():
@@ -50,9 +50,9 @@ def setup_and_launch():
 
         os.environ.update(env)
         setup_scrapy_conf()
-        # init logger [!] missing
-        from estela_scrapy.log import initialize_logging
-        loghdlr = initialize_logging()
+
+        from estela_scrapy.log import init_logging
+        loghdlr = init_logging()
     except:
         logging.exception("Environment variables were not defined properly")
         raise

--- a/estela_scrapy/__main__.py
+++ b/estela_scrapy/__main__.py
@@ -11,7 +11,7 @@ def run_scrapy(argv, settings):
     execute(settings=settings)
 
 
-def run_code(args, commands_module=None):
+def run_code(args, log_handler=None, commands_module=None):
     try:
         from estela_scrapy.settings import populate_settings
 
@@ -19,6 +19,8 @@ def run_code(args, commands_module=None):
         settings = populate_settings()
         if commands_module:
             settings.set("COMMANDS_MODULE", commands_module, priority="cmdline")
+        if log_handler is not None:
+            log_handler.setLevel(settings['LOG_LEVEL'])
     except Exception:
         logging.exception("Settings initialization failed")
         raise
@@ -49,11 +51,13 @@ def setup_and_launch():
         os.environ.update(env)
         setup_scrapy_conf()
         # init logger [!] missing
+        from estela_scrapy.log import initialize_logging
+        loghdlr = initialize_logging()
     except:
         logging.exception("Environment variables were not defined properly")
         raise
 
-    run_code(args)
+    run_code(args, loghdlr)
 
 
 def main():

--- a/estela_scrapy/__main__.py
+++ b/estela_scrapy/__main__.py
@@ -20,7 +20,7 @@ def run_code(args, log_handler=None, commands_module=None):
         if commands_module:
             settings.set("COMMANDS_MODULE", commands_module, priority="cmdline")
         if log_handler is not None:
-            log_handler.setLevel(settings['LOG_LEVEL'])
+            log_handler.setLevel(settings["LOG_LEVEL"])
     except Exception:
         logging.exception("Settings initialization failed")
         raise
@@ -37,7 +37,10 @@ def describe_project():
 
     setup_scrapy_conf()
 
-    run_code(["scrapy", "describe_project"] + sys.argv[1:], commands_module="estela_scrapy.commands")
+    run_code(
+        ["scrapy", "describe_project"] + sys.argv[1:],
+        commands_module="estela_scrapy.commands",
+    )
 
 
 def setup_and_launch():
@@ -52,6 +55,7 @@ def setup_and_launch():
         setup_scrapy_conf()
 
         from estela_scrapy.log import init_logging
+
         loghdlr = init_logging()
     except:
         logging.exception("Environment variables were not defined properly")

--- a/estela_scrapy/log.py
+++ b/estela_scrapy/log.py
@@ -16,10 +16,7 @@ def _logfn(level, message, parent="none"):
     producer = connect_kafka_producer()
     data = {
         "jid": os.getenv("ESTELA_SPIDER_JOB"),
-        "payload": {
-            "log": str(message),
-            "datetime": float(time.time())
-        }
+        "payload": {"log": str(message), "datetime": float(time.time())},
     }
     response = producer.send("job_logs", value=data)
 
@@ -27,28 +24,25 @@ def _logfn(level, message, parent="none"):
 def init_logging():
     # General python logging
     root = logging.getLogger()
-    root.setLevel(logging.NOTSET) # NOSET Make processing all messages if is set in root
-    
+    root.setLevel(
+        logging.NOTSET
+    )  # NOSET Make processing all messages if is set in root
+
     hdlr = LogHandler()
     hdlr.setLevel(logging.INFO)
-    hdlr.setFormatter(logging.Formatter('[%(name)s] %(message)s'))
+    hdlr.setFormatter(logging.Formatter("[%(name)s] %(message)s"))
     root.addHandler(hdlr)
 
     # Silence commonly used noisy libraries
-    try:
-        import boto
-    except ImportError:
-        pass
-
     nh = logging.NullHandler()
-    for ln in ('boto', 'requests', 'kafka.conn'):
+    for ln in ("boto", "requests", "kafka.conn"):
         lg = logging.getLogger(ln)
         lg.propagate = 0
         lg.addHandler(nh)
 
     # Redirect standard output and error
-    sys.stdout = StdoutLogger(False, 'utf-8')
-    sys.stderr = StdoutLogger(True, 'utf-8')
+    sys.stdout = StdoutLogger(False, "utf-8")
+    sys.stderr = StdoutLogger(True, "utf-8")
 
     # Twisted specifics (includes Scrapy)
     obs = LogObserver(hdlr)
@@ -89,14 +83,14 @@ class LogObserver(object):
     def emit(self, ev):
         logitem = self._get_log_item(ev)
         if logitem:
-            _logfn(**logitem,parent="LogObserver")
+            _logfn(**logitem, parent="LogObserver")
 
     def _get_log_item(self, ev):
         """Get logs from scrapy in his level or Info level in other case"""
-        if ev['system'] == 'scrapy':
-            level = ev['logLevel']
+        if ev["system"] == "scrapy":
+            level = ev["logLevel"]
         else:
-            if ev['isError']:
+            if ev["isError"]:
                 level = logging.ERROR
             else:
                 level = logging.INFO
@@ -105,32 +99,33 @@ class LogObserver(object):
         if level < self._hs_loghdlr.level:
             return
 
-        msg = ev.get('message')
+        msg = ev.get("message")
         if msg:
             msg = to_standar_str(msg[0])
 
-        failure = ev.get('failure', None)
+        failure = ev.get("failure", None)
         if failure:
             msg = failure.getTraceback()
 
-        why = ev.get('why', None)
+        why = ev.get("why", None)
         if why:
-            msg = "%s\n%s" % (why, msg)
+            msg = "{}\n{}".format(why, msg)
 
-        fmt = ev.get('format')
+        fmt = ev.get("format")
         if fmt:
             try:
-                msg = fmt % ev
+                msg = fmt.format(ev)
             except:
-                msg = "FAILED TO APPLY FORMAT: fmt=%r ev=%r" % (fmt, ev)
+                msg = "FAILED TO APPLY FORMAT: fmt={} ev={}".format(repr(fmt), repr(ev))
                 level = logging.ERROR
 
-        msg = msg.replace('\n', '\n\t')
-        return {'message': msg, 'level': level}
+        msg = msg.replace("\n", "\n\t")
+        return {"message": msg, "level": level}
 
 
 class StdoutLogger(txlog.StdioOnnaStick):
     """Catch logs from sterr and stdout"""
+
     def __init__(self, isError=False, encoding=None, loglevel=logging.INFO):
         txlog.StdioOnnaStick.__init__(self, isError, encoding)
         self.prefix = "[stderr] " if isError else "[stdout] "
@@ -142,7 +137,7 @@ class StdoutLogger(txlog.StdioOnnaStick):
     def write(self, data):
         data = to_standar_str(data, self.encoding)
 
-        d = (self.buf + data).split('\n')
+        d = (self.buf + data).split("\n")
         self.buf = d[-1]
         messages = d[0:-1]
         for message in messages:

--- a/estela_scrapy/log.py
+++ b/estela_scrapy/log.py
@@ -5,9 +5,6 @@ import warnings
 from twisted.python import log as txlog
 from scrapy import __version__
 
-from sh_scrapy.compat import to_native_str
-from sh_scrapy.writer import pipe_writer
-
 
 # keep a global reference to stderr as it is redirected on log initialization
 _stdout = sys.stdout
@@ -17,11 +14,13 @@ _stderr = sys.stderr
 def _logfn(level, message):
     """Wraps HS job logging function."""
     try:
-        pipe_writer.write_log(level=level, message=message)
+        print("INTERESTING")
+        #pipe_writer.write_log(level=level, message=message)
     except UnicodeDecodeError:
         # workaround for messages that contain binary data
         message = repr(message)[1:-1]
-        pipe_writer.write_log(level=level, message=message)
+        print("INTERESTING 2")
+        #pipe_writer.write_log(level=level, message=message)
 
 
 def initialize_logging():
@@ -118,7 +117,8 @@ class HubstorageLogObserver(object):
 
         msg = ev.get('message')
         if msg:
-            msg = to_native_str(msg[0])
+            msg = "MESSAGE"
+            #msg = to_native_str(msg[0])
 
         failure = ev.get('failure', None)
         if failure:
@@ -154,7 +154,8 @@ class StdoutLogger(txlog.StdioOnnaStick):
         _logfn(message=self.prefix + msg, level=self.loglevel)
 
     def write(self, data):
-        data = to_native_str(data, self.encoding)
+        data = ["line1","line2"]
+        #data = to_native_str(data, self.encoding)
 
         d = (self.buf + data).split('\n')
         self.buf = d[-1]
@@ -164,5 +165,6 @@ class StdoutLogger(txlog.StdioOnnaStick):
 
     def writelines(self, lines):
         for line in lines:
-            line = to_native_str(line, self.encoding)
+            print(line)
+            #line = to_native_str(line, self.encoding)
             self._logprefixed(line)

--- a/estela_scrapy/log.py
+++ b/estela_scrapy/log.py
@@ -1,0 +1,168 @@
+import logging
+import sys
+import warnings
+
+from twisted.python import log as txlog
+from scrapy import __version__
+
+from sh_scrapy.compat import to_native_str
+from sh_scrapy.writer import pipe_writer
+
+
+# keep a global reference to stderr as it is redirected on log initialization
+_stdout = sys.stdout
+_stderr = sys.stderr
+
+
+def _logfn(level, message):
+    """Wraps HS job logging function."""
+    try:
+        pipe_writer.write_log(level=level, message=message)
+    except UnicodeDecodeError:
+        # workaround for messages that contain binary data
+        message = repr(message)[1:-1]
+        pipe_writer.write_log(level=level, message=message)
+
+
+def initialize_logging():
+    """Initialize logging to send messages to Hubstorage job logs
+    it initializes:
+    - Python logging
+    - Twisted logging
+    - Scrapy logging
+    - Redirects standard output and stderr to job log at INFO level
+    This duplicates some code with Scrapy log.start(), but it's required in
+    order to avoid scrapy from starting the log twice.
+    """
+    # General python logging
+    root = logging.getLogger()
+    root.setLevel(logging.NOTSET)
+    hdlr = HubstorageLogHandler()
+    hdlr.setLevel(logging.INFO)
+    hdlr.setFormatter(logging.Formatter('[%(name)s] %(message)s'))
+    root.addHandler(hdlr)
+
+    # Silence commonly used noisy libraries
+    try:
+        import boto  # boto overrides its logger at import time
+    except ImportError:
+        pass
+
+    nh = logging.NullHandler()
+    for ln in ('boto', 'requests', 'hubstorage'):
+        lg = logging.getLogger(ln)
+        lg.propagate = 0
+        lg.addHandler(nh)
+
+    # Redirect standard output and error to HS log
+    sys.stdout = StdoutLogger(0, 'utf-8')
+    sys.stderr = StdoutLogger(1, 'utf-8')
+
+    # Twisted specifics (includes Scrapy)
+    obs = HubstorageLogObserver(hdlr)
+    _oldshowwarning = warnings.showwarning
+    txlog.startLoggingWithObserver(obs.emit, setStdout=False)
+    warnings.showwarning = _oldshowwarning
+    return hdlr
+
+
+class HubstorageLogHandler(logging.Handler):
+    """Python logging handler that writes to HubStorage"""
+
+    def emit(self, record):
+        try:
+            message = self.format(record)
+            if message:
+                _logfn(message=message, level=record.levelno)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)
+
+    def handleError(self, record):
+        cur = sys.stderr
+        try:
+            sys.stderr = _stderr
+            super(HubstorageLogHandler, self).handleError(record)
+        finally:
+            sys.stderr = cur
+
+
+class HubstorageLogObserver(object):
+    """Twisted log observer with Scrapy specifics that writes to HubStorage"""
+
+    def __init__(self, loghdlr):
+        self._hs_loghdlr = loghdlr
+
+    def emit(self, ev):
+        logitem = self._get_log_item(ev)
+        if logitem:
+            _logfn(**logitem)
+
+    def _get_log_item(self, ev):
+        """Get HubStorage log item for the given Twisted event, or None if no
+        document should be inserted
+        """
+        if ev['system'] == 'scrapy':
+            level = ev['logLevel']
+        else:
+            if ev['isError']:
+                level = logging.ERROR
+            else:
+                level = logging.INFO
+
+        # It's important to access level trough handler instance,
+        # min log level can change at any moment.
+        if level < self._hs_loghdlr.level:
+            return
+
+        msg = ev.get('message')
+        if msg:
+            msg = to_native_str(msg[0])
+
+        failure = ev.get('failure', None)
+        if failure:
+            msg = failure.getTraceback()
+
+        why = ev.get('why', None)
+        if why:
+            msg = "%s\n%s" % (why, msg)
+
+        fmt = ev.get('format')
+        if fmt:
+            try:
+                msg = fmt % ev
+            except:
+                msg = "UNABLE TO FORMAT LOG MESSAGE: fmt=%r ev=%r" % (fmt, ev)
+                level = logging.ERROR
+        # to replicate typical scrapy log appeareance
+        msg = msg.replace('\n', '\n\t')
+        return {'message': msg, 'level': level}
+
+
+class StdoutLogger(txlog.StdioOnnaStick):
+    """This works like Twisted's StdioOnnaStick but prepends standard
+    output/error messages with [stdout] and [stderr]
+    """
+
+    def __init__(self, isError=0, encoding=None, loglevel=logging.INFO):
+        txlog.StdioOnnaStick.__init__(self, isError, encoding)
+        self.prefix = "[stderr] " if isError else "[stdout] "
+        self.loglevel = loglevel
+
+    def _logprefixed(self, msg):
+        _logfn(message=self.prefix + msg, level=self.loglevel)
+
+    def write(self, data):
+        data = to_native_str(data, self.encoding)
+
+        d = (self.buf + data).split('\n')
+        self.buf = d[-1]
+        messages = d[0:-1]
+        for message in messages:
+            self._logprefixed(message)
+
+    def writelines(self, lines):
+        for line in lines:
+            line = to_native_str(line, self.encoding)
+            self._logprefixed(line)

--- a/estela_scrapy/utils.py
+++ b/estela_scrapy/utils.py
@@ -12,3 +12,11 @@ def datetime_to_json(o):
     if isinstance(o, datetime):
         return o.__str__()
     raise TypeError("Type %s not serializable" % type(o))
+
+
+def to_standar_str(text, encoding="utf-8", errors='strict'):
+    if isinstance(text, str):
+        return text
+    if not isinstance(text, bytes):
+        raise TypeError("Unable to standardize {} type".format(type(text).__name__))
+    return text.decode(encoding, errors)

--- a/estela_scrapy/utils.py
+++ b/estela_scrapy/utils.py
@@ -11,10 +11,10 @@ def parse_time(date=None):
 def datetime_to_json(o):
     if isinstance(o, datetime):
         return o.__str__()
-    raise TypeError("Type %s not serializable" % type(o))
+    raise TypeError("Type {} not serializable".format(type(o)))
 
 
-def to_standar_str(text, encoding="utf-8", errors='strict'):
+def to_standar_str(text, encoding="utf-8", errors="strict"):
     if isinstance(text, str):
         return text
     if not isinstance(text, bytes):


### PR DESCRIPTION
## Ticket
- https://tasks.bitmaker.dev/issues/1997

## Description
- Add Loghandler to send python logs to kafka.
- Add LogObserver to send scrapy logs to kafka.
- Add StdoutLogger to send stderr logs to kafka.