### PR TITLE
BITMAKER-1929 Setting serializer by default

### DIFF
--- a/estela_scrapy/extensions.py
+++ b/estela_scrapy/extensions.py
@@ -79,7 +79,7 @@ class ItemStorageExtension:
             request_count=spider_stats.get("downloader/request_count", 0),
         )
 
-        parser_stats = json.dumps(spider_stats, default=datetime_to_json)
+        parser_stats = json.dumps(spider_stats, default=str)
         data = {
             "jid": os.getenv("ESTELA_SPIDER_JOB"),
             "payload": json.loads(parser_stats),


### PR DESCRIPTION
# Description

Add default JSON-serializer to handle common non-serializable fields

# Issue

https://tasks.bitmaker.dev/issues/1929

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have made corresponding changes to the [documentation](https://github.com/bitmakerla/estela/tree/main/docs).
- [x] New and existing tests pass locally with my changes.
- [x] If this change is a core feature, I have added thorough tests.
- [x] If this change affects or depends on the behavior of other _estela_ repositories, I have created pull requests with the relevant changes in the affected repositories. Please, refer to our [official documentation](https://estela.bitmaker.la/docs/).
- [x] I understand that my pull request may be closed if it becomes obvious or I did not perform all of the steps above.
